### PR TITLE
toml array comment position fix

### DIFF
--- a/src/main/java/com/moandjiezana/toml/MapValueWriter.java
+++ b/src/main/java/com/moandjiezana/toml/MapValueWriter.java
@@ -72,7 +72,7 @@ class MapValueWriter implements ValueWriter {
       final boolean hasComment = (valueComments != null) && !valueComments.isEmpty() && valueComments.size() > comment && valueComments.get(comment) != null;
       ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
       if (hasComment) {
-        if (valueWriter != ObjectValueWriter.OBJECT_VALUE_WRITER)
+        if (valueWriter != ObjectValueWriter.OBJECT_VALUE_WRITER && valueWriter != TABLE_ARRAY_VALUE_WRITER)
           addComments(valueComments.get(comment), context);
       }
       if (valueWriter.isPrimitiveType()) {
@@ -98,10 +98,15 @@ class MapValueWriter implements ValueWriter {
       }
 
       ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
+      final boolean hasComment = (objComments != null) && !objComments.isEmpty() && objComments.size() > comment && objComments.get(comment) != null;
       if (valueWriter == this || valueWriter == TABLE_ARRAY_VALUE_WRITER) {
+        if (hasComment) {
+          context.write('\n');
+          addComments(objComments.get(comment), context);
+        }
         valueWriter.write(fromValue, context.pushTable(quoteKey(key)));
+        comment++;
       } else if (valueWriter == ObjectValueWriter.OBJECT_VALUE_WRITER) {
-        final boolean hasComment = (objComments != null) && !objComments.isEmpty() && objComments.size() > comment && objComments.get(comment) != null;
         ((ObjectValueWriter) valueWriter).write(fromValue, context.pushTable(quoteKey(key)), hasComment ? objComments.get(comment) : null);
         comment++;
       }

--- a/src/main/java/com/moandjiezana/toml/ObjectValueWriter.java
+++ b/src/main/java/com/moandjiezana/toml/ObjectValueWriter.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 
 import static com.moandjiezana.toml.MapValueWriter.MAP_VALUE_WRITER;
+import static com.moandjiezana.toml.TableArrayValueWriter.TABLE_ARRAY_VALUE_WRITER;
 import static com.moandjiezana.toml.ValueWriters.WRITERS;
 
 class ObjectValueWriter implements ValueWriter {
@@ -74,7 +75,7 @@ class ObjectValueWriter implements ValueWriter {
         for (Annotation a : field.getAnnotations()) {
           if (a instanceof TomlComment) {
             TomlComment comment = (TomlComment) a;
-            if (valueWriter == OBJECT_VALUE_WRITER)
+            if (valueWriter == OBJECT_VALUE_WRITER || valueWriter == TABLE_ARRAY_VALUE_WRITER)
               objComments.add(comment.value());
             else
               comments.add(comment.value());
@@ -82,7 +83,7 @@ class ObjectValueWriter implements ValueWriter {
           }
         }
       } else {
-        if (valueWriter == OBJECT_VALUE_WRITER)
+        if (valueWriter == OBJECT_VALUE_WRITER || valueWriter == TABLE_ARRAY_VALUE_WRITER)
           objComments.add(null);
         else
           comments.add(null);


### PR DESCRIPTION
Toml  comments for tables were writen like they were primitives, this pr inserts the comments in the correct location.